### PR TITLE
Fix position of fuselages

### DIFF
--- a/simple_yasim_import.py
+++ b/simple_yasim_import.py
@@ -794,7 +794,7 @@ class Fuselage(Item):
         # set the object location, where to place this ? It's placed at point ax,ay,az !
         #  I'm assuming this is always the tip of the tube, otherways it might not be displayed correctly ?
         #  ==> maybe find a solution for this... ?
-        fus_obj.location = a
+        fus_obj.matrix_world = Matrix.Translation(a)
         
         # link the object to the actual scene
         bpy.context.scene.collection.objects.link(fus_obj)


### PR DESCRIPTION
Sometimes in Blender 3.0.1 all fuselages appear to show up positioned at
the origin unless followed by a tank, ballast, or weight.

Setting the fuselage position using matrix_world however seems to work
around the issue.

Note: I don't fully understand the fix, its simply inspired by other functions which do something similar and seem to imply that setting location doesn't work there sometimes either.